### PR TITLE
Delete boat when rentals

### DIFF
--- a/app/controllers/boats_controller.rb
+++ b/app/controllers/boats_controller.rb
@@ -43,8 +43,12 @@ class BoatsController < ApplicationController
 
   def delete_my_boat
     @boat = Boat.find(params[:id])
-    @boat.destroy
-    redirect_to myboats_path, status: :see_other
+    if @boat.rentals.empty?
+      @boat.destroy
+      redirect_to myboats_path, status: :see_other, notice: "Boat successfully deleted."
+    else
+      redirect_to myboats_path, status: :see_other, alert: "Cannot delete boat with existing rentals."
+    end
   end
 
 

--- a/app/controllers/boats_controller.rb
+++ b/app/controllers/boats_controller.rb
@@ -47,7 +47,7 @@ class BoatsController < ApplicationController
       @boat.destroy
       redirect_to myboats_path, status: :see_other, notice: "Boat successfully deleted."
     else
-      redirect_to myboats_path, status: :see_other, alert: "Cannot delete boat with existing rentals."
+      redirect_to myboats_path, status: :see_other, alert: "Cannot delete boat with rentals pending"
     end
   end
 


### PR DESCRIPTION
The button broke when there was a rental associated to a Boat.
controller: added an if, and an alert indicating it cannot be deleted if there is a rental associated